### PR TITLE
Fix aggregation mode visitor for containments

### DIFF
--- a/lib/msfl_visitors/visitor.rb
+++ b/lib/msfl_visitors/visitor.rb
@@ -164,7 +164,7 @@ module MSFLVisitors
             # [:aggs, {node.name.accept(visitor).to_sym => Hash[[node.value.accept(visitor)]]}]
             node.value.accept(visitor)
           when Nodes::Containment
-            { terms: {node.left.accept(visitor).to_sym => node.right.accept(visitor)} }
+            { agg_field_name: node.left.accept(visitor).to_sym, operator: :in, test_value: node.right.accept(visitor) }
           when Nodes::Set
             node.contents.map { |n| n.accept(visitor) }
           when Nodes::Filter

--- a/lib/msfl_visitors/visitor.rb
+++ b/lib/msfl_visitors/visitor.rb
@@ -120,8 +120,6 @@ module MSFLVisitors
       def visit(node)
         case node
           when Nodes::Partial
-            # { given: Hash[[node.left.accept(visitor), node.right.accept(visitor)]] }
-
             # build the aggregate criteria clause first
             # agg_criteria_clause = { clause: { agg_field_name: :portfolio_size, operator: :gt, test_value: 2 }, method_to_execute: :aggregations }
             agg_criteria_clause = { clause: node.right.accept(visitor), method_to_execute: :aggregations }
@@ -134,12 +132,8 @@ module MSFLVisitors
             # return the result of the visitation
             [agg_criteria_clause, given_clause]
 
-
-
           when Nodes::Equal
-            # { term: { node.left.accept(visitor) => node.right.accept(visitor) } }
             { agg_field_name: node.left.accept(visitor), operator: :eq, test_value: node.right.accept(visitor) }
-            # [{ clause:  }]
           when Nodes::Field
             node.value.to_sym
           when Nodes::Date, Nodes::Time
@@ -154,14 +148,11 @@ module MSFLVisitors
                 Nodes::LessThan,
                 Nodes::LessThanEqual
             { agg_field_name: node.left.accept(visitor), operator: RANGE_OPERATORS[node.class], test_value: node.right.accept(visitor) }
-            # { range: { node.left.accept(visitor) => { RANGE_OPERATORS[node.class] =>  node.right.accept(visitor) } } }
           when Nodes::Given
             [:filter, node.contents.first.accept(visitor)]
           when Nodes::ExplicitFilter
-            # [:filter, node.contents.map { |n| n.accept(visitor) }.reduce({}) { |hsh, x| hsh.merge!(x); hsh } ]
             node.contents.map { |n| n.accept(visitor) }.first
           when Nodes::NamedValue
-            # [:aggs, {node.name.accept(visitor).to_sym => Hash[[node.value.accept(visitor)]]}]
             node.value.accept(visitor)
           when Nodes::Containment
             { agg_field_name: node.left.accept(visitor).to_sym, operator: :in, test_value: node.right.accept(visitor) }

--- a/spec/visitors/chewy_term_filter_spec.rb
+++ b/spec/visitors/chewy_term_filter_spec.rb
@@ -162,8 +162,9 @@ describe MSFLVisitors::Visitor do
 
         before { visitor.mode = :aggregations }
 
-        it "results in: { terms: { lhs: [\"item_one\", \"item_two\", \"item_three\"] } }" do
-          expect(subject).to eq({ terms: { lhs: ["item_one", "item_two", "item_three"] } })
+        it "results in: { agg_field_name: :lhs, operator: :in, test_value: [\"item_one\", \"item_two\", \"item_three\"] }" do
+
+          expect(subject).to eq({ agg_field_name: :lhs, operator: :in, test_value: ["item_one", "item_two", "item_three"] })
         end
       end
     end
@@ -536,9 +537,9 @@ describe MSFLVisitors::Visitor do
 
           before { visitor.mode = :aggregations }
 
-          it "returns: { and: [{ terms: { make: [\"Honda\",\"Chevy\",\"Volvo\"]} }, { agg_field_name: :value, operator: :gte, test_value: 1000 } }] }" do
+          it "returns: { and: [{ agg_field_name: :make, operator: :in, test_value: [\"Honda\", \"Chevy\", \"Volvo\"] }, { agg_field_name: :value, operator: :gte, test_value: 1000 } }] }" do
             expected = { and: [
-                { terms: { make: ["Honda", "Chevy", "Volvo"] } },
+                { agg_field_name: :make, operator: :in, test_value: ["Honda", "Chevy", "Volvo"] },
                 { agg_field_name: :value, operator: :gte, test_value: 1000}
             ]}
             expect(result).to eq expected


### PR DESCRIPTION
In one of the rewrites of the aggregations mode visitor we / I missed updating how we handle containment nodes.

This PR resolves same.