### PR TITLE
Escape es specific regex chars

### DIFF
--- a/lib/msfl_visitors/visitor.rb
+++ b/lib/msfl_visitors/visitor.rb
@@ -101,7 +101,7 @@ module MSFLVisitors
           when  Nodes::Match
             if node.right.is_a? Nodes::Set
               escaped_str = node.right.contents.map { |right_child| MSFLVisitors::Nodes::Regex.new(right_child.value.to_s).accept(visitor).inspect[3..-4] }.join('|')
-              "#{node.left.accept(visitor)} #{BINARY_OPERATORS[node.class]} " + escaped_regex_helper(escaped_str).inspect
+              "#{node.left.accept(visitor)} #{BINARY_OPERATORS[node.class]} " + %r[.*#{escaped_str}.*].inspect
             else
               "#{node.left.accept(visitor)} #{BINARY_OPERATORS[node.class]} " + MSFLVisitors::Nodes::Regex.new(node.right.value.to_s).accept(visitor).inspect
             end

--- a/lib/msfl_visitors/visitor.rb
+++ b/lib/msfl_visitors/visitor.rb
@@ -9,8 +9,9 @@ module MSFLVisitors
       str.gsub(/([@&<>~])/) { |m| "\\#{m}" }
     end
 
-    def escaped_regex_helper(escaped_str)
-      exp = escape_es_special_regex_chars "#{escaped_str}"
+    def regex_escape(escaped_str)
+      esc = Regexp.escape("#{escaped_str.to_s}")
+      exp = escape_es_special_regex_chars "#{esc}"
       # why you must use #inspect, not #to_s. @link http://ruby-doc.org/core-1.9.3/Regexp.html#method-i-3D-7E
       %r[.*#{exp}.*]
     end
@@ -97,8 +98,7 @@ module MSFLVisitors
           when  Nodes::Field
             node.value.to_s
           when Nodes::Regex
-            esc = Regexp.escape("#{node.value.to_s}")
-            escaped_regex_helper esc
+            regex_escape node.value.to_s
           when  Nodes::Word
             "\"#{node.value}\""
           when Nodes::Date, Nodes::Time
@@ -205,8 +205,7 @@ module MSFLVisitors
                 Nodes::Dataset
             node.value
           when  Nodes::Regex
-            esc = Regexp.escape("#{node.value.to_s}")
-            composable_expr_for(escaped_regex_helper(esc).inspect)
+            composable_expr_for(regex_escape(node.value.to_s).inspect)
 
           when  Nodes::GreaterThan,
                 Nodes::GreaterThanEqual,

--- a/lib/msfl_visitors/visitor.rb
+++ b/lib/msfl_visitors/visitor.rb
@@ -56,6 +56,12 @@ module MSFLVisitors
       str.gsub(/([@&<>~])/) { |m| "\\#{m}" }
     end
 
+    def escaped_regex_helper(escaped_str)
+      exp = escape_es_special_regex_chars "#{escaped_str}"
+      # why you must use #inspect, not #to_s. @link http://ruby-doc.org/core-1.9.3/Regexp.html#method-i-3D-7E
+      %r[.*#{exp}.*]
+    end
+
     private
 
     attr_reader :mode
@@ -75,11 +81,7 @@ module MSFLVisitors
           Nodes::Match                  => '=~',
       }
 
-      def escaped_regex_helper(escaped_str)
-        exp = visitor.escape_es_special_regex_chars "#{escaped_str}"
-        # why you must use #inspect, not #to_s. @link http://ruby-doc.org/core-1.9.3/Regexp.html#method-i-3D-7E
-        %r[.*#{exp}.*]
-      end
+
 
       def visit(node)
         case node
@@ -87,7 +89,7 @@ module MSFLVisitors
             node.value.to_s
           when Nodes::Regex
             esc = Regexp.escape("#{node.value.to_s}")
-            escaped_regex_helper esc
+            visitor.escaped_regex_helper esc
           when  Nodes::Word
             "\"#{node.value}\""
           when Nodes::Date, Nodes::Time
@@ -192,7 +194,8 @@ module MSFLVisitors
                 Nodes::Dataset
             node.value
           when  Nodes::Regex
-            Regexp.escape(node.value.to_s)
+            esc = Regexp.escape("#{node.value.to_s}")
+            visitor.escaped_regex_helper(esc).inspect[3..-4]
 
           when  Nodes::GreaterThan,
                 Nodes::GreaterThanEqual,

--- a/msfl_visitors.gemspec
+++ b/msfl_visitors.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'msfl_visitors'
-  s.version     = '1.2.0'
-  s.date        = '2015-06-19'
+  s.version     = '1.2.1'
+  s.date        = '2015-07-06'
   s.summary     = "Convert MSFL to other forms"
   s.description = "Visitor pattern approach to converting MSFL to other forms."
   s.authors     = ["Courtland Caldwell"]

--- a/msfl_visitors.gemspec
+++ b/msfl_visitors.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'msfl_visitors'
-  s.version     = '1.2.1'
+  s.version     = '1.2.2'
   s.date        = '2015-07-06'
   s.summary     = "Convert MSFL to other forms"
   s.description = "Visitor pattern approach to converting MSFL to other forms."

--- a/spec/msfl_visitors/visitor_spec.rb
+++ b/spec/msfl_visitors/visitor_spec.rb
@@ -11,4 +11,20 @@ describe MSFLVisitors::Visitor do
       expect(subject.send(:mode)).to eq :term
     end
   end
+
+  describe "#escape_es_special_regex_chars" do
+
+    {
+        'ab@cd' => 'ab\@cd',
+        'ab&cd' => 'ab\&cd',
+        'ab<cd' => 'ab\<cd',
+        'ab>cd' => 'ab\>cd',
+        'ab~cd' => 'ab\~cd',
+    }.each do |str, expected|
+
+      it "escapes '#{str}' as '#{expected}'" do
+        expect(MSFLVisitors::Visitor.new.escape_es_special_regex_chars str).to eq expected
+      end
+    end
+  end
 end

--- a/spec/msfl_visitors/visitor_spec.rb
+++ b/spec/msfl_visitors/visitor_spec.rb
@@ -14,6 +14,7 @@ describe MSFLVisitors::Visitor do
 
   describe "#escape_es_special_regex_chars" do
 
+    include MSFLVisitors::VisitorHelpers
     {
         'ab@cd' => 'ab\@cd',
         'ab&cd' => 'ab\&cd',
@@ -23,7 +24,7 @@ describe MSFLVisitors::Visitor do
     }.each do |str, expected|
 
       it "escapes '#{str}' as '#{expected}'" do
-        expect(MSFLVisitors::Visitor.new.escape_es_special_regex_chars str).to eq expected
+        expect(escape_es_special_regex_chars str).to eq expected
       end
     end
   end

--- a/spec/msfl_visitors/visitors/chewy_term_filter_spec.rb
+++ b/spec/msfl_visitors/visitors/chewy_term_filter_spec.rb
@@ -235,6 +235,15 @@ describe MSFLVisitors::Visitor do
           expected =  /.*a\ \#sentence\@\ contain\&ing\ \<lucene\>\ cha\~rs.*/
           expect(result).to eq expected
         end
+
+        context "when using the Aggregations visitor" do
+
+          before { visitor.mode = :aggregations }
+
+          it "escapes lucene specific special characters" do
+            expect(result).to eq "a\\ \\#sentence\\@\\ contain\\&ing\\ \\<lucene\\>\\ cha\\~rs"
+          end
+        end
       end
 
       context "when the regex contains characters that require escaping" do
@@ -251,8 +260,8 @@ describe MSFLVisitors::Visitor do
 
           before { visitor.mode = :aggregations }
 
-          it "returns: 'this\\ /\\ needs\\ to\\ %\\ \\{be,escaped\\}\\ \\*\\.\\ \\^\\[or\\]\\ \\|\\ \\\\else'" do
-            expect(result).to eq "this\\ /\\ needs\\ to\\ %\\ \\{be,escaped\\}\\ \\*\\.\\ \\^\\[or\\]\\ \\|\\ \\\\else"
+          it "returns: 'this\\ \\/\\ needs\\ to\\ %\\ \\{be,escaped\\}\\ \\*\\.\\ \\^\\[or\\]\\ \\|\\ \\\\else'" do
+            expect(result).to eq "this\\ \\/\\ needs\\ to\\ %\\ \\{be,escaped\\}\\ \\*\\.\\ \\^\\[or\\]\\ \\|\\ \\\\else"
           end
         end
       end

--- a/spec/msfl_visitors/visitors/chewy_term_filter_spec.rb
+++ b/spec/msfl_visitors/visitors/chewy_term_filter_spec.rb
@@ -298,6 +298,15 @@ describe MSFLVisitors::Visitor do
           end
         end
 
+        context "when using the Aggregations visitor" do
+
+          before { visitor.mode = :aggregations }
+
+          it %(results in: { agg_field_name: :lhs, operator: :match, test_value: "this\\ \\(ne\\&eds\\)\\ to\\ be\\*\\ escaped" }) do
+            expected = { agg_field_name: :lhs, operator: :match, test_value: "this\\ \\(ne\\&eds\\)\\ to\\ be\\*\\ escaped" }
+            expect(result).to eq expected
+          end
+        end
       end
 
       context "when the right hand side is a Set node containing Value nodes" do
@@ -332,6 +341,15 @@ describe MSFLVisitors::Visitor do
 
           it "results in: { agg_field_name: :lhs, operator: :match, test_value: \"foo|bar|baz\" }" do
             expect(result).to eq({agg_field_name: :lhs, operator: :match, test_value: "foo|bar|baz"})
+          end
+
+          context "when one of the members of the Set requires escaping" do
+
+            let(:foo_node) { MSFLVisitors::Nodes::Word.new "please&*escape me" }
+
+            it "results in { agg_field_name: :lhs, operator: :match, test_value: \"please\\&\\*escape\\ me }" do
+              expected = { agg_field_name: :lhs, operator: :match, test_value: "please\\&\\*escape\\ me" }
+            end
           end
         end
       end

--- a/spec/msfl_visitors/visitors/chewy_term_filter_spec.rb
+++ b/spec/msfl_visitors/visitors/chewy_term_filter_spec.rb
@@ -280,12 +280,12 @@ describe MSFLVisitors::Visitor do
 
       context "when the right hand side is a Value node that requires escaping" do
 
-        let(:right) { MSFLVisitors::Nodes::Word.new 'this (needs) to be* escaped' }
+        let(:right) { MSFLVisitors::Nodes::Word.new 'this (ne&eds) to be* escaped' }
 
         context "when using the TermFilter visitor" do
 
-          it "results in: 'left =~ /.*this\ \(needs\)\ to\ be\*\ escaped.*/'" do
-            expect(result).to eq %(lhs =~ ) + /.*this\ \(needs\)\ to\ be\*\ escaped.*/.inspect
+          it "results in: 'left =~ /.*this\ \(ne\&eds\)\ to\ be\*\ escaped.*/'" do
+            expect(result).to eq %(lhs =~ ) + /.*this\ \(ne\&eds\)\ to\ be\*\ escaped.*/.inspect
           end
         end
 
@@ -305,6 +305,15 @@ describe MSFLVisitors::Visitor do
 
           it "results in: 'left =~ /.*foo|bar|baz.*/'" do
             expect(result).to eq %(lhs =~ ) + /.*foo|bar|baz.*/.inspect
+          end
+
+          context "when one of the members of the Set requires escaping" do
+
+            let(:foo_node) { MSFLVisitors::Nodes::Word.new "please&*escape me" }
+
+            it "escapes special characters" do
+              expect(result).to eq %(lhs =~ ) + /.*please\&\*escape\ me|bar|baz.*/.inspect
+            end
           end
         end
 


### PR DESCRIPTION
Update the visitor code to explicitly escape some supplemental characters in regexes that are passed into elasticsearch.