### PR TITLE
Regex or group

### DIFF
--- a/lib/msfl_visitors/visitor.rb
+++ b/lib/msfl_visitors/visitor.rb
@@ -112,7 +112,7 @@ module MSFLVisitors
           when  Nodes::Match
             if node.right.is_a? Nodes::Set
               escaped_str_frags = node.right.contents.map { |right_child| composable_expr_for(MSFLVisitors::Nodes::Regex.new(right_child.value.to_s).accept(visitor).inspect) }
-              escaped_str = escaped_str_frags.join('|')
+              escaped_str = "(" + escaped_str_frags.join('|') + ")"
               "#{node.left.accept(visitor)} #{BINARY_OPERATORS[node.class]} " + %r[.*#{escaped_str}.*].inspect
             else
               "#{node.left.accept(visitor)} #{BINARY_OPERATORS[node.class]} " + MSFLVisitors::Nodes::Regex.new(node.right.value.to_s).accept(visitor).inspect
@@ -188,8 +188,7 @@ module MSFLVisitors
 
           when Nodes::Match
             if node.right.is_a? Nodes::Set
-              regex = node.right.contents.map { |right_child| MSFLVisitors::Nodes::Regex.new(right_child.value.to_s).accept(visitor) }.join('|')
-              # regex = node.right.contents.map { |right_child| right_child.value.to_s }.join('|')
+              regex = "(" + node.right.contents.map { |right_child| MSFLVisitors::Nodes::Regex.new(right_child.value.to_s).accept(visitor) }.join('|') + ")"
               { agg_field_name: node.left.accept(visitor), operator: :match, test_value: regex }
             else
               { agg_field_name: node.left.accept(visitor), operator: :match, test_value: MSFLVisitors::Nodes::Regex.new(node.right.value.to_s).accept(visitor) }
@@ -246,6 +245,7 @@ module MSFLVisitors
       attr_reader :visitor
     end
 
+    # ESTermFilterVisitor is not currently used and so not all node types are implemented
     class ESTermFilterVisitor
       def initialize(visitor)
         @visitor = visitor

--- a/msfl_visitors.gemspec
+++ b/msfl_visitors.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'msfl_visitors'
-  s.version     = '1.2.2'
-  s.date        = '2015-07-06'
+  s.version     = '1.2.3'
+  s.date        = '2015-07-09'
   s.summary     = "Convert MSFL to other forms"
   s.description = "Visitor pattern approach to converting MSFL to other forms."
   s.authors     = ["Courtland Caldwell"]

--- a/spec/msfl_visitors/visitors/chewy_term_filter_spec.rb
+++ b/spec/msfl_visitors/visitors/chewy_term_filter_spec.rb
@@ -321,8 +321,8 @@ describe MSFLVisitors::Visitor do
 
         context "when using the TermFilter visitor" do
 
-          it "results in: 'left =~ /.*foo|bar|baz.*/'" do
-            expect(result).to eq %(lhs =~ ) + /.*foo|bar|baz.*/.inspect
+          it "results in: 'left =~ /.*(foo|bar|baz).*/'" do
+            expect(result).to eq %(lhs =~ ) + /.*(foo|bar|baz).*/.inspect
           end
 
           context "when one of the members of the Set requires escaping" do
@@ -330,7 +330,7 @@ describe MSFLVisitors::Visitor do
             let(:foo_node) { MSFLVisitors::Nodes::Word.new "please&*escape me" }
 
             it "escapes special characters" do
-              expect(result).to eq %(lhs =~ ) + /.*please\&\*escape\ me|bar|baz.*/.inspect
+              expect(result).to eq %(lhs =~ ) + /.*(please\&\*escape\ me|bar|baz).*/.inspect
             end
           end
         end
@@ -339,16 +339,17 @@ describe MSFLVisitors::Visitor do
 
           before { visitor.mode = :aggregations }
 
-          it "results in: { agg_field_name: :lhs, operator: :match, test_value: \"foo|bar|baz\" }" do
-            expect(result).to eq({agg_field_name: :lhs, operator: :match, test_value: "foo|bar|baz"})
+          it "results in: { agg_field_name: :lhs, operator: :match, test_value: \"(foo|bar|baz)\" }" do
+            expect(result).to eq({agg_field_name: :lhs, operator: :match, test_value: "(foo|bar|baz)"})
           end
 
           context "when one of the members of the Set requires escaping" do
 
             let(:foo_node) { MSFLVisitors::Nodes::Word.new "please&*escape me" }
 
-            it "results in { agg_field_name: :lhs, operator: :match, test_value: \"please\\&\\*escape\\ me }" do
-              expected = { agg_field_name: :lhs, operator: :match, test_value: "please\\&\\*escape\\ me" }
+            it "results in { agg_field_name: :lhs, operator: :match, test_value: \"(please\\&\\*escape\\ me|bar|baz) }" do
+              expected = { agg_field_name: :lhs, operator: :match, test_value: "(please\\&\\*escape\\ me|bar|baz)" }
+              expect(result).to eq expected
             end
           end
         end


### PR DESCRIPTION
Patch defect that created partially incorrect ES regexp's when the match node's right child was a Set node.